### PR TITLE
Implement RC-specific quorum when round higher than a threshold

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -82,9 +82,8 @@ linters-settings:
     numbers: true
 
   goimports:
-    local-prefixes: github.com/0xPolygon/go-ibft
-                    github.com/armon/go-metrics
-    
+    local-prefixes: github.com/Hydra-Chain/go-ibft
+      github.com/armon/go-metrics
 
   nestif:
     min-complexity: 4

--- a/build/main.go
+++ b/build/main.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/0xPolygon/go-ibft/core"
+	"github.com/Hydra-Chain/go-ibft/core"
 )
 
 func main() {

--- a/core/backend.go
+++ b/core/backend.go
@@ -3,8 +3,8 @@
 package core
 
 import (
-	"github.com/0xPolygon/go-ibft/messages"
-	"github.com/0xPolygon/go-ibft/messages/proto"
+	"github.com/Hydra-Chain/go-ibft/messages"
+	"github.com/Hydra-Chain/go-ibft/messages/proto"
 )
 
 // MessageConstructor defines a message constructor interface

--- a/core/byzantine_test.go
+++ b/core/byzantine_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/0xPolygon/go-ibft/messages/proto"
+	"github.com/Hydra-Chain/go-ibft/messages/proto"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/core/consensus_test.go
+++ b/core/consensus_test.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/0xPolygon/go-ibft/messages"
-	"github.com/0xPolygon/go-ibft/messages/proto"
+	"github.com/Hydra-Chain/go-ibft/messages"
+	"github.com/Hydra-Chain/go-ibft/messages/proto"
 )
 
 // generateNodeAddresses generates dummy node addresses

--- a/core/drop_test.go
+++ b/core/drop_test.go
@@ -80,6 +80,93 @@ func TestDropAllAndRecover(t *testing.T) {
 	assertValidInsertedBlocks(t, insertedBlocks) // Make sure the inserted blocks are valid
 }
 
+func TestRecoverFromDifferentRounds(t *testing.T) {
+	t.Parallel()
+
+	var (
+		numNodes       = uint64(10)
+		insertedBlocks = make([][]byte, numNodes)
+		desiredRounds  = []uint64{
+			5,
+			6,
+			6,
+			7,
+			4,
+			9, // we have 30% nodes on a higher round
+			9, // others will move there
+			9,
+			7,
+			5,
+		}
+	)
+
+	cluster := newCluster(
+		numNodes,
+		func(c *cluster) {
+			for nodeIndex, node := range c.nodes {
+				i := nodeIndex
+				currentNode := node
+				backend := &mockBackend{
+					isValidProposalFn:      isValidProposal,
+					isValidProposalHashFn:  isValidProposalHash,
+					IsValidValidatorFn:     nil,
+					isValidCommittedSealFn: nil,
+					isProposerFn:           c.isProposer,
+
+					idFn: node.addr,
+
+					buildProposalFn:           buildValidEthereumBlock,
+					buildPrePrepareMessageFn:  node.buildPrePrepare,
+					buildPrepareMessageFn:     node.buildPrepare,
+					buildCommitMessageFn:      node.buildCommit,
+					buildRoundChangeMessageFn: node.buildRoundChange,
+
+					insertProposalFn: func(proposal *proto.Proposal, _ []*messages.CommittedSeal) {
+						insertedBlocks[i] = proposal.RawProposal
+					},
+					getVotingPowerFn: testCommonGetVotingPowertFnForNodes(c.nodes),
+				}
+				node.core = &IBFT{
+					log:     mockLogger{},
+					backend: backend,
+					transport: &mockTransport{multicastFn: func(message *proto.Message) {
+						if currentNode.offline {
+							return
+						}
+
+						c.gossip(message)
+					}},
+					messages:         messages.NewMessages(),
+					roundDone:        make(chan struct{}),
+					roundExpired:     make(chan struct{}),
+					newProposal:      make(chan newProposalEvent),
+					roundCertificate: make(chan uint64),
+					state: &mockState{
+						state: &state{
+							view: &proto.View{
+								Height: 0,
+								Round:  desiredRounds[nodeIndex],
+							},
+							seals:        make([]*messages.CommittedSeal, 0),
+							roundStarted: false,
+							name:         newRound,
+						},
+						desiredStartRound: desiredRounds[nodeIndex],
+					},
+					baseRoundTimeout: DefaultBaseRoundTimeout,
+					validatorManager: NewValidatorManager(backend, mockLogger{}),
+				}
+			}
+		},
+	)
+
+	// Progress the chain to claim it works ok
+	err := cluster.progressToHeight(180*time.Second, 1)
+	assert.NoError(t, err, "unable to reach height: %w", err)
+	assert.Equal(t, uint64(1), cluster.latestHeight)
+	assertValidInsertedBlocks(t, insertedBlocks) // Make sure the inserted blocks are valid
+}
+
 func assertNInsertedBlocks(t *testing.T, n int, blocks [][]byte) {
 	t.Helper()
 

--- a/core/drop_test.go
+++ b/core/drop_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/0xPolygon/go-ibft/messages"
-	"github.com/0xPolygon/go-ibft/messages/proto"
+	"github.com/Hydra-Chain/go-ibft/messages"
+	"github.com/Hydra-Chain/go-ibft/messages/proto"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/core/helpers.go
+++ b/core/helpers.go
@@ -1,0 +1,26 @@
+package core
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+func runTaskPeriodically(ctx context.Context, wg *sync.WaitGroup, task func(), interval time.Duration) {
+	wg.Add(1)
+	task()
+
+	defer wg.Done()
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			task()
+		case <-ctx.Done():
+			return
+		}
+	}
+}

--- a/core/helpers_test.go
+++ b/core/helpers_test.go
@@ -10,7 +10,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/0xPolygon/go-ibft/messages/proto"
+	"github.com/Hydra-Chain/go-ibft/messages/proto"
 )
 
 /*	HELPERS */

--- a/core/ibft.go
+++ b/core/ibft.go
@@ -1355,6 +1355,10 @@ func (i *IBFT) subscribe(details messages.SubscriptionDetails) *messages.Subscri
 //   - round 3: 4 sec
 //   - round 4: 8 sec
 func getRoundTimeout(baseRoundTimeout, additionalTimeout time.Duration, round uint64) time.Duration {
+	if round > longRoundThreshold {
+		return 10 * time.Minute
+	}
+
 	var (
 		baseDuration = int(baseRoundTimeout)
 		roundFactor  = int(math.Pow(roundFactorBase, float64(round)))

--- a/core/ibft.go
+++ b/core/ibft.go
@@ -1271,7 +1271,9 @@ func (i *IBFT) hasQuorumByMsgType(msgs []*proto.Message, msgType proto.MessageTy
 		return len(msgs) >= 1
 	case proto.MessageType_PREPARE:
 		return i.validatorManager.HasPrepareQuorum(i.state.getStateName(), i.state.getProposalMessage(), msgs)
-	case proto.MessageType_ROUND_CHANGE, proto.MessageType_COMMIT:
+	case proto.MessageType_ROUND_CHANGE:
+		return i.validatorManager.HasRoundChangeQuorum(i.state.getRound(), convertMessageToAddressSet(msgs))
+	case proto.MessageType_COMMIT:
 		return i.validatorManager.HasQuorum(convertMessageToAddressSet(msgs))
 	default:
 		return false

--- a/core/ibft.go
+++ b/core/ibft.go
@@ -7,8 +7,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/0xPolygon/go-ibft/messages"
-	"github.com/0xPolygon/go-ibft/messages/proto"
+	"github.com/Hydra-Chain/go-ibft/messages"
+	"github.com/Hydra-Chain/go-ibft/messages/proto"
 	"github.com/armon/go-metrics"
 )
 

--- a/core/ibft.go
+++ b/core/ibft.go
@@ -55,13 +55,37 @@ var (
 	errTimeoutExpired = errors.New("round timeout expired")
 )
 
+// State represents the IBFT state
+type State interface {
+	changeState(name stateType)
+	finalizePrepare(certificate *proto.PreparedCertificate, latestPPB *proto.Proposal)
+	getCommittedSeals() []*messages.CommittedSeal
+	getHeight() uint64
+	getLatestPC() *proto.PreparedCertificate
+	getLatestPreparedProposal() *proto.Proposal
+	getProposal() *proto.Proposal
+	getProposalHash() []byte
+	getProposalMessage() *proto.Message
+	getRawDataFromProposal() []byte
+	getRound() uint64
+	getRoundStarted() bool
+	getStateName() stateType
+	getView() *proto.View
+	newRound()
+	reset(height uint64)
+	setCommittedSeals(seals []*messages.CommittedSeal)
+	setProposalMessage(proposalMessage *proto.Message)
+	setRoundStarted(started bool)
+	setView(view *proto.View)
+}
+
 // IBFT represents a single instance of the IBFT state machine
 type IBFT struct {
 	// log is the logger instance
 	log Logger
 
 	// state is the current IBFT node state
-	state *state
+	state State
 
 	// messages is the message storage layer
 	messages Messages

--- a/core/ibft_test.go
+++ b/core/ibft_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/0xPolygon/go-ibft/messages"
-	"github.com/0xPolygon/go-ibft/messages/proto"
+	"github.com/Hydra-Chain/go-ibft/messages"
+	"github.com/Hydra-Chain/go-ibft/messages/proto"
 )
 
 func proposalMatches(proposal *proto.Proposal, message *proto.Message) bool {

--- a/core/ibft_test.go
+++ b/core/ibft_test.go
@@ -284,10 +284,10 @@ func TestRunNewRound_Proposer(t *testing.T) {
 			i.wg.Wait()
 
 			// Make sure the node is in prepare state
-			assert.Equal(t, prepare, i.state.name)
+			assert.Equal(t, prepare, i.state.getStateName())
 
 			// Make sure the accepted proposal is the one proposed to other nodes
-			assert.Equal(t, multicastedProposal, i.state.proposalMessage)
+			assert.Equal(t, multicastedProposal, i.state.getProposalMessage())
 
 			// Make sure the accepted proposal matches what was built
 			assert.True(
@@ -412,10 +412,10 @@ func TestRunNewRound_Proposer(t *testing.T) {
 			i.wg.Wait()
 
 			// Make sure the node changed the state to prepare
-			assert.Equal(t, prepare, i.state.name)
+			assert.Equal(t, prepare, i.state.getStateName())
 
 			// Make sure the multicasted proposal is the accepted proposal
-			assert.Equal(t, multicastedPreprepare, i.state.proposalMessage)
+			assert.Equal(t, multicastedPreprepare, i.state.getProposalMessage())
 
 			// Make sure the correct proposal value was multicasted
 			assert.True(t, proposalMatches(correctRoundMessage.proposal, multicastedPreprepare))
@@ -584,10 +584,10 @@ func TestRunNewRound_Proposer(t *testing.T) {
 			i.wg.Wait()
 
 			// Make sure the node changed the state to prepare
-			assert.Equal(t, prepare, i.state.name)
+			assert.Equal(t, prepare, i.state.getStateName())
 
 			// Make sure the multicasted proposal is the accepted proposal
-			assert.Equal(t, multicastedPreprepare, i.state.proposalMessage)
+			assert.Equal(t, multicastedPreprepare, i.state.getProposalMessage())
 
 			// Make sure the correct proposal was multicasted
 			assert.True(t, proposalMatches(lastPreparedProposedProposal, multicastedPreprepare))
@@ -687,7 +687,7 @@ func TestRunNewRound_Validator_Zero(t *testing.T) {
 	i.wg.Wait()
 
 	// Make sure the node moves to prepare state
-	assert.Equal(t, prepare, i.state.name)
+	assert.Equal(t, prepare, i.state.getStateName())
 
 	// Make sure the accepted proposal is the one that was sent out
 	assert.Equal(t, correctRoundMessage.proposal, i.state.getProposal())
@@ -854,7 +854,7 @@ func TestRunNewRound_Validator_NonZero(t *testing.T) {
 			i.wg.Wait()
 
 			// Make sure the node moves to prepare state
-			assert.Equal(t, prepare, i.state.name)
+			assert.Equal(t, prepare, i.state.getStateName())
 
 			// Make sure the accepted proposal is the one that was sent out
 			assert.Equal(t, roundMessage.proposal, i.state.getProposal())
@@ -940,16 +940,16 @@ func TestRunPrepare(t *testing.T) {
 
 			i := NewIBFT(log, backend, transport)
 			require.NoError(t, i.validatorManager.Init(0))
-			i.state.name = prepare
-			i.state.roundStarted = true
-			i.state.proposalMessage = &proto.Message{
+			i.state.changeState(prepare)
+			i.state.setRoundStarted(true)
+			i.state.setProposalMessage(&proto.Message{
 				Payload: &proto.Message_PreprepareData{
 					PreprepareData: &proto.PrePrepareMessage{
 						Proposal:     correctRoundMessage.proposal,
 						ProposalHash: correctRoundMessage.hash,
 					},
 				},
-			}
+			})
 			i.messages = &messages
 
 			// Make sure the notification is present
@@ -961,7 +961,7 @@ func TestRunPrepare(t *testing.T) {
 			i.wg.Wait()
 
 			// Make sure the node moves to the commit state
-			assert.Equal(t, commit, i.state.name)
+			assert.Equal(t, commit, i.state.getStateName())
 
 			// Make sure the proposal didn't change
 			assert.Equal(t, correctRoundMessage.proposal, i.state.getProposal())
@@ -1044,16 +1044,16 @@ func TestRunCommit(t *testing.T) {
 			i := NewIBFT(log, backend, transport)
 			require.NoError(t, i.validatorManager.Init(0))
 			i.messages = messages
-			i.state.proposalMessage = &proto.Message{
+			i.state.setProposalMessage(&proto.Message{
 				Payload: &proto.Message_PreprepareData{
 					PreprepareData: &proto.PrePrepareMessage{
 						Proposal:     correctRoundMessage.proposal,
 						ProposalHash: correctRoundMessage.hash,
 					},
 				},
-			}
-			i.state.roundStarted = true
-			i.state.name = commit
+			})
+			i.state.setRoundStarted(true)
+			i.state.changeState(commit)
 
 			ctx, cancelFn := context.WithCancel(context.Background())
 
@@ -1083,7 +1083,7 @@ func TestRunCommit(t *testing.T) {
 			i.insertBlock()
 
 			// Make sure the node changed the state to fin
-			require.Equal(t, fin, i.state.name)
+			require.Equal(t, fin, i.state.getStateName())
 
 			// Make sure the inserted proposal was the one present
 			require.Equal(t, insertedProposal, correctRoundMessage.proposal.RawProposal)
@@ -1204,7 +1204,7 @@ func TestIBFT_IsAcceptableMessage(t *testing.T) {
 			)
 
 			i := NewIBFT(log, backend, transport)
-			i.state.view = testCase.stateView
+			i.state.setView(testCase.stateView)
 
 			message := &proto.Message{
 				View: testCase.msgView,
@@ -1319,7 +1319,7 @@ func TestIBFT_MoveToNewRound(t *testing.T) {
 		assert.Nil(t, i.state.getProposal())
 
 		// Make sure the state is correct
-		assert.Equal(t, newRound, i.state.name)
+		assert.Equal(t, newRound, i.state.getStateName())
 	})
 }
 
@@ -2968,17 +2968,17 @@ func TestIBFT_RunSequence_NewProposal(t *testing.T) {
 	i.RunSequence(ctx, height)
 
 	// Make sure the correct proposal message was accepted
-	assert.Equal(t, ev.proposalMessage, i.state.proposalMessage)
+	assert.Equal(t, ev.proposalMessage, i.state.getProposalMessage())
 
 	// Make sure the correct round was moved to
-	assert.Equal(t, ev.round, i.state.view.Round)
-	assert.Equal(t, height, i.state.view.Height)
+	assert.Equal(t, ev.round, i.state.getView().Round)
+	assert.Equal(t, height, i.state.getView().Height)
 
 	// Make sure the round has been started
-	assert.True(t, i.state.roundStarted)
+	assert.True(t, i.state.getRoundStarted())
 
 	// Make sure the state is the prepare state
-	assert.Equal(t, prepare, i.state.name)
+	assert.Equal(t, prepare, i.state.getStateName())
 }
 
 // TestIBFT_RunSequence_FutureRCC verifies that the
@@ -3017,17 +3017,17 @@ func TestIBFT_RunSequence_FutureRCC(t *testing.T) {
 	i.RunSequence(ctx, height)
 
 	// Make sure the proposal message is not set
-	assert.Nil(t, i.state.proposalMessage)
+	assert.Nil(t, i.state.getProposalMessage())
 
 	// Make sure the correct round was moved to
-	assert.Equal(t, round, i.state.view.Round)
-	assert.Equal(t, height, i.state.view.Height)
+	assert.Equal(t, round, i.state.getView().Round)
+	assert.Equal(t, height, i.state.getView().Height)
 
 	// Make sure the new round has been started
-	assert.True(t, i.state.roundStarted)
+	assert.True(t, i.state.getRoundStarted())
 
 	// Make sure the state is the new round state
-	assert.Equal(t, newRound, i.state.name)
+	assert.Equal(t, newRound, i.state.getStateName())
 }
 
 // TestIBFT_ExtendRoundTimer makes sure the round timeout
@@ -3166,7 +3166,7 @@ func TestIBFT_AddMessage(t *testing.T) {
 		i := NewIBFT(log, backend, transport)
 		require.NoError(t, i.validatorManager.Init(0))
 		i.messages = messages
-		i.state.view = &proto.View{Height: validHeight, Round: validRound}
+		i.state.setView(&proto.View{Height: validHeight, Round: validRound})
 
 		i.AddMessage(msg)
 

--- a/core/mock_test.go
+++ b/core/mock_test.go
@@ -8,8 +8,8 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/0xPolygon/go-ibft/messages"
-	"github.com/0xPolygon/go-ibft/messages/proto"
+	"github.com/Hydra-Chain/go-ibft/messages"
+	"github.com/Hydra-Chain/go-ibft/messages/proto"
 )
 
 const (

--- a/core/mock_test.go
+++ b/core/mock_test.go
@@ -561,3 +561,26 @@ func (m *mockCluster) setBaseTimeout(timeout time.Duration) {
 		node.baseRoundTimeout = timeout
 	}
 }
+
+// IBFT state mock so we can replicate conditions where validators have huge round state differences
+type mockState struct {
+	*state
+	desiredStartRound uint64
+}
+
+func (s *mockState) reset(height uint64) {
+	s.Lock()
+	defer s.Unlock()
+
+	s.seals = nil
+	s.roundStarted = false
+	s.name = newRound
+	s.proposalMessage = nil
+	s.latestPC = nil
+	s.latestPreparedProposal = nil
+
+	s.view = &proto.View{
+		Height: height,
+		Round:  s.desiredStartRound,
+	}
+}

--- a/core/rapid_test.go
+++ b/core/rapid_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"pgregory.net/rapid"
 
-	"github.com/0xPolygon/go-ibft/messages"
-	"github.com/0xPolygon/go-ibft/messages/proto"
+	"github.com/Hydra-Chain/go-ibft/messages"
+	"github.com/Hydra-Chain/go-ibft/messages/proto"
 )
 
 // roundMessage contains message data within consensus round

--- a/core/state.go
+++ b/core/state.go
@@ -174,6 +174,13 @@ func (s *state) changeState(name stateType) {
 	s.name = name
 }
 
+func (s *state) getRoundStarted() bool {
+	s.RLock()
+	defer s.RUnlock()
+
+	return s.roundStarted
+}
+
 func (s *state) setRoundStarted(started bool) {
 	s.Lock()
 	defer s.Unlock()

--- a/core/state.go
+++ b/core/state.go
@@ -3,8 +3,8 @@ package core
 import (
 	"sync"
 
-	"github.com/0xPolygon/go-ibft/messages"
-	"github.com/0xPolygon/go-ibft/messages/proto"
+	"github.com/Hydra-Chain/go-ibft/messages"
+	"github.com/Hydra-Chain/go-ibft/messages/proto"
 )
 
 type stateType uint8

--- a/core/transport.go
+++ b/core/transport.go
@@ -1,6 +1,6 @@
 package core
 
-import "github.com/0xPolygon/go-ibft/messages/proto"
+import "github.com/Hydra-Chain/go-ibft/messages/proto"
 
 // Transport defines an interface
 // the node uses to communicate with other peers

--- a/core/validator_manager.go
+++ b/core/validator_manager.go
@@ -6,7 +6,7 @@ import (
 	"math/big"
 	"sync"
 
-	"github.com/0xPolygon/go-ibft/messages/proto"
+	"github.com/Hydra-Chain/go-ibft/messages/proto"
 )
 
 const (

--- a/core/validator_manager.go
+++ b/core/validator_manager.go
@@ -32,7 +32,7 @@ type ValidatorManager struct {
 	quorumSize *big.Int
 
 	// rcMinQuorum represents the voting power needed to create a round change certificate
-	// when round is above rcMinQuorumThreshold for the height specified in the current View
+	// when the round is above rcMinQuorumThreshold for the height specified in the current View
 	rcMinQuorum *big.Int
 
 	// validatorsVotingPower is a map of the validator addresses on their voting power for

--- a/core/validator_manager.go
+++ b/core/validator_manager.go
@@ -141,7 +141,7 @@ func (vm *ValidatorManager) HasPrepareQuorum(stateName stateType, proposalMessag
 // When round is above rcMinQuorumThreshold we allow for easier RC quorum
 // to achieve faster restore in case of network stall. Otherwise we use the default quorum.
 func (vm *ValidatorManager) HasRoundChangeQuorum(currentRound uint64, sendersAddrs map[string]struct{}) bool {
-	if currentRound <= rcMinQuorumThreshold {
+	if vm.rcMinQuorum != nil || currentRound <= rcMinQuorumThreshold {
 		return vm.HasQuorum(sendersAddrs)
 	}
 
@@ -174,6 +174,11 @@ func calculateQuorum(totalVotingPower *big.Int) *big.Int {
 // calculateRCMinQuorum calculates a special RC quorum size
 // Quorum is FLOOR(30%)
 func calculateRCMinQuorum(totalVotingPower *big.Int) *big.Int {
+	// totalVotingPower < 10, don't allow rcMinQuorum option
+	if totalVotingPower.Cmp(big.NewInt(10)) == -1 {
+		return nil
+	}
+
 	quorum := new(big.Int).Mul(totalVotingPower, big.NewInt(30))
 
 	return quorum.Div(quorum, big.NewInt(100))

--- a/core/validator_manager.go
+++ b/core/validator_manager.go
@@ -141,7 +141,7 @@ func (vm *ValidatorManager) HasPrepareQuorum(stateName stateType, proposalMessag
 // When round is above rcMinQuorumThreshold we allow for easier RC quorum
 // to achieve faster restore in case of network stall. Otherwise we use the default quorum.
 func (vm *ValidatorManager) HasRoundChangeQuorum(currentRound uint64, sendersAddrs map[string]struct{}) bool {
-	if vm.rcMinQuorum != nil || currentRound <= rcMinQuorumThreshold {
+	if vm.rcMinQuorum == nil || currentRound <= rcMinQuorumThreshold {
 		return vm.HasQuorum(sendersAddrs)
 	}
 

--- a/core/validator_manager_test.go
+++ b/core/validator_manager_test.go
@@ -203,9 +203,169 @@ func Test_calculateRCMinQuorum(t *testing.T) {
 			totalVotingPower: big.NewInt(9),
 			expected:         nil,
 		},
+		{
+			totalVotingPower: big.NewInt(10),
+			expected:         big.NewInt(3),
+		},
+		{
+			totalVotingPower: big.NewInt(115),
+			expected:         big.NewInt(34),
+		},
+		{
+			totalVotingPower: big.NewInt(1085),
+			expected:         big.NewInt(325),
+		},
+		{
+			totalVotingPower: big.NewInt(12763),
+			expected:         big.NewInt(3828),
+		},
+		{
+			totalVotingPower: big.NewInt(999999999),
+			expected:         big.NewInt(299999999),
+		},
 	}
 
 	for _, c := range cases {
 		require.Equal(t, c.expected, calculateRCMinQuorum(c.totalVotingPower))
+	}
+}
+
+func Test_HasRoundChangeQuorum(t *testing.T) {
+	t.Parallel()
+
+	vm := &ValidatorManager{
+		vpLock: &sync.RWMutex{},
+	}
+
+	cases := []struct {
+		round                 uint64
+		validatorsVotingPower map[string]*big.Int
+		hasQuorum             bool
+		signers               map[string]struct{}
+	}{
+		{
+			round: 5,
+			validatorsVotingPower: map[string]*big.Int{
+				"A": big.NewInt(1),
+			},
+			signers:   map[string]struct{}{},
+			hasQuorum: false,
+		},
+		{
+			round: 5,
+			validatorsVotingPower: map[string]*big.Int{
+				"A": big.NewInt(1),
+			},
+			signers: map[string]struct{}{
+				"A": {},
+			},
+			hasQuorum: true,
+		},
+		{
+			round: 5,
+			validatorsVotingPower: map[string]*big.Int{
+				"A": big.NewInt(4),
+				"B": big.NewInt(4),
+			},
+			signers: map[string]struct{}{
+				"A": {},
+			},
+			hasQuorum: false,
+		},
+		{
+			round: 6,
+			validatorsVotingPower: map[string]*big.Int{
+				"A": big.NewInt(4),
+				"B": big.NewInt(4),
+			},
+			signers: map[string]struct{}{
+				"A": {},
+			},
+			hasQuorum: false,
+		},
+		{
+			round: 5,
+			validatorsVotingPower: map[string]*big.Int{
+				"A": big.NewInt(5),
+				"B": big.NewInt(5),
+			},
+			signers: map[string]struct{}{
+				"A": {},
+			},
+			hasQuorum: false,
+		},
+		{
+			round: 6,
+			validatorsVotingPower: map[string]*big.Int{
+				"A": big.NewInt(5),
+				"B": big.NewInt(5),
+			},
+			signers: map[string]struct{}{
+				"A": {},
+			},
+			hasQuorum: true,
+		},
+		{
+			round: 6,
+			validatorsVotingPower: map[string]*big.Int{
+				"A": big.NewInt(2),
+				"B": big.NewInt(7),
+				"C": big.NewInt(6),
+				"D": big.NewInt(6),
+			},
+			signers: map[string]struct{}{
+				"C": {},
+			},
+			hasQuorum: true,
+		},
+		{
+			round: 6,
+			validatorsVotingPower: map[string]*big.Int{
+				"A": big.NewInt(6),
+				"B": big.NewInt(7),
+				"C": big.NewInt(6),
+				"D": big.NewInt(6),
+			},
+			signers: map[string]struct{}{
+				"C": {},
+			},
+			hasQuorum: false,
+		},
+		{
+			round: 6,
+			validatorsVotingPower: map[string]*big.Int{
+				"A": big.NewInt(15783),
+				"B": big.NewInt(11432),
+				"C": big.NewInt(13242),
+				"D": big.NewInt(14324),
+				"E": big.NewInt(32141),
+			},
+			signers: map[string]struct{}{
+				"B": {},
+				"C": {},
+			},
+			hasQuorum: false,
+		},
+		{
+			round: 6,
+			validatorsVotingPower: map[string]*big.Int{
+				"A": big.NewInt(15783),
+				"B": big.NewInt(11432),
+				"C": big.NewInt(13242),
+				"D": big.NewInt(14324),
+				"E": big.NewInt(32141),
+			},
+			signers: map[string]struct{}{
+				"B": {},
+				"C": {},
+				"D": {},
+			},
+			hasQuorum: true,
+		},
+	}
+
+	for _, c := range cases {
+		require.NoError(t, vm.setCurrentVotingPower(c.validatorsVotingPower))
+		require.Equal(t, c.hasQuorum, vm.HasRoundChangeQuorum(c.round, c.signers))
 	}
 }

--- a/core/validator_manager_test.go
+++ b/core/validator_manager_test.go
@@ -191,3 +191,21 @@ func Test_CalculateQuorum(t *testing.T) {
 		require.Equal(t, c.hasQuorum, vm.HasQuorum(c.signers))
 	}
 }
+
+func Test_calculateRCMinQuorum(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		totalVotingPower *big.Int
+		expected         *big.Int
+	}{
+		{
+			totalVotingPower: big.NewInt(9),
+			expected:         nil,
+		},
+	}
+
+	for _, c := range cases {
+		require.Equal(t, c.expected, calculateRCMinQuorum(c.totalVotingPower))
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/0xPolygon/go-ibft
+module github.com/Hydra-Chain/go-ibft
 
 go 1.21
 

--- a/messages/event_manager.go
+++ b/messages/event_manager.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/google/uuid"
 
-	"github.com/0xPolygon/go-ibft/messages/proto"
+	"github.com/Hydra-Chain/go-ibft/messages/proto"
 )
 
 type eventManager struct {

--- a/messages/event_manager_test.go
+++ b/messages/event_manager_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/0xPolygon/go-ibft/messages/proto"
+	"github.com/Hydra-Chain/go-ibft/messages/proto"
 )
 
 func TestEventManager_SubscribeCancel(t *testing.T) {

--- a/messages/event_subscription.go
+++ b/messages/event_subscription.go
@@ -1,7 +1,7 @@
 package messages
 
 import (
-	"github.com/0xPolygon/go-ibft/messages/proto"
+	"github.com/Hydra-Chain/go-ibft/messages/proto"
 )
 
 type eventSubscription struct {

--- a/messages/event_subscription_test.go
+++ b/messages/event_subscription_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/0xPolygon/go-ibft/messages/proto"
+	"github.com/Hydra-Chain/go-ibft/messages/proto"
 )
 
 func TestEventSubscription_EventSupported(t *testing.T) {

--- a/messages/helpers.go
+++ b/messages/helpers.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"errors"
 
-	"github.com/0xPolygon/go-ibft/messages/proto"
+	"github.com/Hydra-Chain/go-ibft/messages/proto"
 )
 
 var (

--- a/messages/helpers_test.go
+++ b/messages/helpers_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/0xPolygon/go-ibft/messages/proto"
+	"github.com/Hydra-Chain/go-ibft/messages/proto"
 )
 
 var proposalHash = []byte("proposal hash")

--- a/messages/messages.go
+++ b/messages/messages.go
@@ -3,7 +3,7 @@ package messages
 import (
 	"sync"
 
-	"github.com/0xPolygon/go-ibft/messages/proto"
+	"github.com/Hydra-Chain/go-ibft/messages/proto"
 )
 
 // Messages contains the relevant messages for each view (height, round)

--- a/messages/messages_test.go
+++ b/messages/messages_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/goleak"
 
-	"github.com/0xPolygon/go-ibft/messages/proto"
+	"github.com/Hydra-Chain/go-ibft/messages/proto"
 )
 
 // generateRandomMessages generates random messages for the


### PR DESCRIPTION
# Description
Faster halt resolution when validators
Require a smaller quorum for round change if the round is above 5 (goes there for ~5 minutes). Let's say 30% of the voting power thinks the right round is 12, other validators are fine to go on this round. 

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)